### PR TITLE
[FE] fix send email, remove button edit email template on payslip preview

### DIFF
--- a/angular/src/app/modules/employees/employee-list/employee-list.component.html
+++ b/angular/src/app/modules/employees/employee-list/employee-list.component.html
@@ -3,7 +3,7 @@
         <div class="w-100 d-flex justify-content-between">
             <app-bread-crumb  [listBreadCrumb]="listBreadCrumb"></app-bread-crumb>
             <div>
-                <button [disabled]="isLoading" (click)="OnSyncToAllEmployees()" _ngcontent-fqs-c454="" class="mat-menu-trigger btn btn-warning mr-2 ng-star-inserted" ng-reflect-menu="[object Object]" aria-haspopup="true">
+                <button [disabled]="isLoading" *ngIf="isShowButtonSyncAllEmployeeToOtherTool()" (click)="OnSyncToAllEmployees()" _ngcontent-fqs-c454="" class="mat-menu-trigger btn btn-warning mr-2 ng-star-inserted" ng-reflect-menu="[object Object]" aria-haspopup="true">
                     Sync all employees to other tools
                 </button>    
                 <app-create-button *ngIf="isShowCreateBtn()" (create)="onCreate()"></app-create-button>
@@ -11,7 +11,7 @@
                     <i class="fa-solid fa-download mr-1"></i>
                     Export employee
                 </button>
-                <button class="btn btn-success ml-2" (click)="exportStatistic()">
+                <button *ngIf="isShowExportBtn()" class="btn btn-success ml-2" (click)="exportStatistic()">
                     <i class="fa-solid fa-download mr-1"></i>
                     Export Statistic
                 </button>

--- a/angular/src/app/modules/employees/employee-list/employee-list.component.ts
+++ b/angular/src/app/modules/employees/employee-list/employee-list.component.ts
@@ -64,6 +64,9 @@ export class EmployeeListComponent extends PagedListingComponentBase<GetEmployee
   isShowBranch() {
     return this.isGranted(PERMISSIONS_CONSTANT.Employee_View);
   }
+  isShowButtonSyncAllEmployeeToOtherTool(){
+    return this.isGranted(PERMISSIONS_CONSTANT.Employee_SyncUpdateEmployeesInforToOtherTools)
+  }
 
   getListNotHavePermission(){
     if (!this.isShowBranch()) this.listNotHavePermission.push("Branch")

--- a/angular/src/app/modules/salaries/payslip-detail/payslip-detail-preview/payslip-detail-preview.component.html
+++ b/angular/src/app/modules/salaries/payslip-detail/payslip-detail-preview/payslip-detail-preview.component.html
@@ -2,7 +2,6 @@
     <div *ngIf="mailInfo?.bodyMessage" class="container-fluid">
         <div class="d-flex px-2 mt-2 mb-2" *ngIf="isShowActions()">
             <div class="col-6">
-                <button class="btn btn-secondary mr-2" (click)="onEdit()">Edit</button>
                 <button class="btn btn-primary" [disabled]="sending" (click)="sendMail()">
                     {{sending? "Sending..." : "Send"}}
                 </button>

--- a/angular/src/app/modules/salaries/payslip-detail/payslip-detail-preview/payslip-detail-preview.component.ts
+++ b/angular/src/app/modules/salaries/payslip-detail/payslip-detail-preview/payslip-detail-preview.component.ts
@@ -51,9 +51,10 @@ export class PayslipDetailPreviewComponent extends AppComponentBase implements O
   sendMail() {
     abp.message.confirm(`Send mai to ${this.mailInfo.sendToEmail}`, "", rs => {
       if (rs) {
+        this.payslipService.getPayslipPreviewToSendEmail(this.payslipId).subscribe((rs) => {
         let dto = {
           payslipId: this.payslipId,
-          mailContent: this.mailInfo,
+          mailContent: rs.result.mailInfo,
           deadline: this.formatDateYMDHm(this.deadline)
         } as SendMailOneemployeeDto
 
@@ -64,30 +65,11 @@ export class PayslipDetailPreviewComponent extends AppComponentBase implements O
           },
             () => { this.isLoading = false })
         )
-      }
+      })}
     })
 
   }
-
-  onEdit() {
-    const editMailDialogData: EditEmailDialogData = {
-      mailInfo: cloneDeep(this.mailInfo),
-      showDialogHeader: false,
-      temporarySave: true,
-    }
-    const dialogRef = this.dialog.open(EditEmailDialogComponent, {
-      data: editMailDialogData,
-      width: '1600px',
-      panelClass: 'email-dialog'
-    })
-    dialogRef.afterClosed().subscribe(rs => {
-      if (rs) {
-        this.mailInfo = cloneDeep(rs)
-      }
-    })
-  }
-
-
+  
   getMailContent() {
     this.payslipService.getEmailTemplate(this.payslipId).subscribe(rs => {
       this.mailInfo = rs.result.mailInfo

--- a/angular/src/app/permission/permission.ts
+++ b/angular/src/app/permission/permission.ts
@@ -176,6 +176,7 @@ export const PERMISSIONS_CONSTANT = {
     Employee_UpdateEmployeeByFile: 'Employee.UpdateEmployeeByFile',
     Employee_DownloadCreateTemplate: 'Employee.DownloadCreateTemplate',
     Employee_DownloadUpdateTemplate: 'Employee.DownloadUpdateTemplate',
+    Employee_SyncUpdateEmployeesInforToOtherTools: 'Employee.SyncUpdateEmployeesInforToOtherTools',
     Employee_EmployeeDetail: 'Employee.EmployeeDetail',
     Employee_EmployeeDetail_TabPersonalInfo: 'Employee.EmployeeDetail.TabPersonalInfo',
     Employee_EmployeeDetail_TabPersonalInfo_View: 'Employee.EmployeeDetail.TabPersonalInfo.View',

--- a/aspnet-core/src/HRMv2.Core/Manager/Salaries/Payslips/PayslipManager.cs
+++ b/aspnet-core/src/HRMv2.Core/Manager/Salaries/Payslips/PayslipManager.cs
@@ -3001,7 +3001,7 @@ namespace HRMv2.Manager.Salaries.Payslips
 
             var sessionEmail = this.GetSessionUserEmail();
            
-            if(sessionEmail != activePayslip.Employee.Email)
+            if(sessionEmail != activePayslip.Employee.Email.Trim().ToLower())
             {
                 return $"bạn không thể khiếu nại phiếu lương của <strong>{activePayslip.Employee.Email}</strong>. <br/>Sự truy cập bất hợp pháp này đã được gửi tới bộ phận HR. ";
             }


### PR DESCRIPTION
+[FE] on component payslip preview: 
        - old version: send mail payslip template
        - new version  : send mail payslip link template
        - remove button edit mail template before send mail to employee
+[FE][BE] permission :
        - add PERMISSIONS_CONSTANT: Employee_SyncUpdateEmployeesInforToOtherTools on FE
        - add permisson for button SyncUpdateEmployeesInforToOtherTools and button export Static(use permission export)
 +[BE] payslipmanager : 
        - old : can't be checked if there are mixed uppercase or lowercase letters
        - new : can be check 